### PR TITLE
Improve finalize override error messages with suggestions

### DIFF
--- a/sws/config.py
+++ b/sws/config.py
@@ -184,7 +184,14 @@ class Config(_BaseView):
             suffix = suffix.removeprefix("c.")
             matches = [k for k in self._store if ("." + k).endswith("." + suffix)]
             if not matches:
-                raise AttributeError(suffix)
+                import difflib
+                suggestions = difflib.get_close_matches(
+                    suffix, list(self._store.keys()), n=5, cutoff=0
+                )
+                msg = f"Unknown override key {suffix!r}"
+                if suggestions:
+                    msg += "; did you mean " + ", ".join(suggestions) + "?"
+                raise AttributeError(msg)
             if len(matches) > 1:  # Ambiguous suffix; help user disambiguate
                 raise AttributeError(
                     f"Ambiguous override key {suffix!r}; candidates:\n"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -29,8 +29,17 @@ def test_suffix():
     assert c.finalize(["simple=99"]).simple == 99
     assert c.finalize(["voc=99"]).model.head.params.voc == 99
 
-    with pytest.raises(AttributeError):
-        c.finalize(["ple=99"]).simple
+    with pytest.raises(AttributeError) as e:
+        c.finalize(["ple=99"])
+    msg = str(e.value)
+    assert "ple" in msg
+    assert "simple" in msg
+
+    with pytest.raises(AttributeError) as e:
+        c.finalize(["lrr=10"])
+    msg = str(e.value)
+    assert "model.head.lr" in msg
+    assert "thingy.lr" in msg
 
     f = c.finalize(["head.lr=99"])
     assert f.thingy.lr == 0.1
@@ -114,6 +123,13 @@ def test_overrides_inexistent():
         c.finalize(["lol=0.001"])
     with pytest.raises(AttributeError):
         c.finalize(["model.expand=2"])
+
+
+def test_overrides_suggestion():
+    c = Config(lr=0.1, model=dict(width=128, depth=4))
+    with pytest.raises(AttributeError) as e:
+        c.finalize(["model.widht=64"])
+    assert "model.width" in str(e.value)
 
 
 def test_overrides_expressions():


### PR DESCRIPTION
## Summary
- Suggest close matches for unknown override keys by relaxing difflib's cutoff and showing top candidates
- Expand tests to assert user-facing messages for typoed override keys `ple` and `lrr`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74283e6248321b89bf39407994e40