### PR TITLE
Allow overwriting inner nodes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ See `example/sweep.fish` for a trivial sweep over a few values.
 
 - The `FinalConfig` has a nice pretty printer when cast to string or printed.
 - When a dict is assigned to a `Config` field, it's turned into a `Config`.
-- You cannot set a group to a value or vice-versa, i.e. no `c.model = "vit"`
-  followed by `c.model.depth = 4` or vice-versa.
+- Assigning a value to a group replaces its subtree (e.g. `c.model = "vit"` clears
+  all `c.model.*`), and assigning a dict to a leaf replaces the leaf with a group.
 - Cycles in computed callables are detected and raise an exception at `finalize`.
 - When setting values via commandline args, you can use the syntax `name:=value`
   to create the exact field `c.name` even if it does not exist. This can be useful

--- a/sws/__init__.py
+++ b/sws/__init__.py
@@ -10,7 +10,7 @@ def run(main, *, argv=None, config_flag="--config", default_func="get_config", f
       specified function (default: `get_config`) to obtain a builder `Config`.
     - Partitions remaining argv into config overrides and unused tokens:
       all `key=value` tokens are passed to `finalize` (which will raise on
-      unknown keys or invalid group assignments). If `forward_extras` is True,
+      unknown keys). If `forward_extras` is True,
       non `key=value` tokens are forwarded to `main` as a second positional
       argument `unused` with preserved order; otherwise they are ignored here.
     - Calls `main(finalized_config, unused_tokens)` when `forward_extras` is True,

--- a/sws/config.py
+++ b/sws/config.py
@@ -89,7 +89,6 @@ class Config(_BaseView):
 
     - Stores all values in a single flat dict of full dotted keys.
     - Accessing a group returns a prefixed view sharing the same store.
-    - Disallows shadowing: a name cannot be both a leaf and a group.
     """
 
     def __init__(self, **kw):
@@ -106,9 +105,17 @@ class Config(_BaseView):
         return new
 
     def _assign_leaf(self, full, value):
-        # Forbid assigning a leaf where a group exists
-        if any(k.startswith(full + ".") for k in self._store):
-            raise ValueError(f"Cannot set leaf '{full}': group with same name exists")
+        # Assigning a leaf replaces any existing subtree and clears conflicting ancestors.
+        prefix = full + "."
+        to_del = [k for k in list(self._store) if k.startswith(prefix)]
+        for k in to_del:
+            del self._store[k]
+        if "." in full:
+            parts = full.split(".")
+            for i in range(1, len(parts)):
+                anc = ".".join(parts[:i])
+                if anc in self._store:
+                    del self._store[anc]
         self._store[full] = value
 
     def _assign(self, full, value):
@@ -116,8 +123,8 @@ class Config(_BaseView):
         if isinstance(value, _BaseView):
             value = value.to_dict()
         if isinstance(value, Mapping):
-            if full in self._store:  # Forbid creating a group where a leaf exists
-                raise ValueError(f"Cannot set group '{full}': leaf with same name exists")
+            if full in self._store:
+                del self._store[full]
             for fk, v in _flatten(full, value):
                 self._assign_leaf(fk, v)
         else:
@@ -181,8 +188,8 @@ class Config(_BaseView):
         self._phase = "finalize"
 
         # Apply overrides if provided. Support `key=value` for existing keys
-        # (with suffix matching), and `key:=value` to create-or-set an exact
-        # dotted key (no suffix matching, creates if missing).
+        # (with suffix matching over leaves and group roots), and `key:=value`
+        # to create-or-set an exact dotted key (no suffix matching, creates if missing).
         evaluator = EvalWithCompoundTypes(names={"c": self}, functions={"Fn": Fn, "range": range})
         def parse_val(val):
             def _lazy():
@@ -196,7 +203,7 @@ class Config(_BaseView):
         for token in list(argv or []):
             if ":=" in token:
                 k, v = token.split(":=", 1)
-                # Use internal assign to respect shadowing rules and allow mappings
+                # Use internal assign to respect overwrite rules and allow mappings
                 self._assign(k.removeprefix("c."), parse_val(v))
                 continue
 
@@ -206,22 +213,37 @@ class Config(_BaseView):
 
             raw_key, v = token.split("=", 1)
 
-            # Find the keys which have this suffix. If multiple, provide error.
+            # Find the keys or group-roots which have this suffix. If multiple, provide error.
             suffix = raw_key.removeprefix("c.")
-            if raw_key.startswith("c.") and suffix in self._store:
-                matches = [suffix]
-            else:
-                matches = [k for k in self._store if ("." + k).endswith("." + suffix)]
-            if not matches:
+            explicit = raw_key.startswith("c.")
+
+            group_roots = None
+
+            def _group_roots():
+                nonlocal group_roots
+                if group_roots is None:
+                    roots = set()
+                    for k in self._store:
+                        parts = k.split(".")
+                        for i in range(1, len(parts)):
+                            roots.add(".".join(parts[:i]))
+                    group_roots = roots
+                return group_roots
+
+            def _raise_unknown():
+                keys = list(self._store)
+                roots = _group_roots()
+                if roots:
+                    keys.extend(sorted(roots))
                 # First, try fuzzy match against full dotted keys
-                suggestions = difflib.get_close_matches(suffix, self._store)
+                suggestions = difflib.get_close_matches(suffix, keys)
                 # Also try fuzzy match against last segments (common typo case),
                 # then expand those to full keys sharing that last segment.
                 num_segs = suffix.count(".") + 1
-                seg_candidates = {".".join(k.split(".")[-num_segs:]) for k in self._store}
+                seg_candidates = {".".join(k.split(".")[-num_segs:]) for k in keys}
                 seg_matches = difflib.get_close_matches(suffix, seg_candidates)
                 for seg in seg_matches:
-                    suggestions.extend(k for k in self._store if k.endswith("." + seg) or k == seg)
+                    suggestions.extend(k for k in keys if k.endswith("." + seg) or k == seg)
                 # Deduplicate while preserving order
                 seen = set()
                 suggestions = [s for s in suggestions if not (s in seen or seen.add(s))]
@@ -229,14 +251,35 @@ class Config(_BaseView):
                 if suggestions:
                     msg += "; did you mean:\n" + "\n".join(suggestions)
                 raise AttributeError(msg)
-            if len(matches) > 1:  # Ambiguous suffix; help user disambiguate
+
+            def _raise_ambiguous(candidates):
                 msg = f"Ambiguous override key {suffix!r}; candidates:\n" \
-                      + '\n'.join(sorted(matches))
-                if suffix in self._store and not raw_key.startswith("c."):
+                      + '\n'.join(sorted(candidates))
+                if (suffix in self._store or suffix in _group_roots()) and not explicit:
                     msg += f"\nHint: use 'c.{suffix}=VALUE' to target that exact key."
                 raise AttributeError(msg)
 
-            self._store[matches[0]] = parse_val(v)
+            # Exact match when explicitly prefixed with c.
+            if explicit and suffix in self._store:
+                target = suffix
+            elif explicit and suffix in _group_roots():
+                target = suffix
+            else:
+                leaf_matches = [k for k in self._store if ("." + k).endswith("." + suffix)]
+                if len(leaf_matches) > 1:
+                    _raise_ambiguous(leaf_matches)
+                if len(leaf_matches) == 1:
+                    target = leaf_matches[0]
+                else:
+                    group_matches = [g for g in _group_roots() if ("." + g).endswith("." + suffix)]
+                    if len(group_matches) > 1:
+                        _raise_ambiguous(group_matches)
+                    if len(group_matches) == 1:
+                        target = group_matches[0]
+                    else:
+                        _raise_unknown()
+
+            self._assign(target, parse_val(v))
 
         # Now go over all items and resolve those that were lazy.
         finalized_store = {k: self[k] for k in self._store}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,21 +114,25 @@ def test_reading_leaves_is_disallowed():
 
 
 def test_shadowing_rules():
-    # Cannot set leaf at group root when group exists
+    # Overwriting a group with a leaf clears the subtree
     c = Config(model=dict(width=128))
-    with pytest.raises(ValueError):
-        c.model = 5
+    c.model = 5
+    f = c.finalize()
+    assert f.model == 5
+    assert "model.width" not in f.to_flat_dict()
 
-    # Cannot set group when a leaf exists at exact root
+    # Leaf access is still disallowed pre-finalize
     c2 = Config(lr=3)
     with pytest.raises(TypeError):
         c2.lr.schedule = 128
 
-def test_forbid_creating_group_where_leaf_exists():
-    # Assigning a mapping at a key that already holds a leaf must fail
+def test_overwrite_leaf_with_group():
+    # Assigning a mapping at a key that already holds a leaf replaces it
     c = Config(lr=3)
-    with pytest.raises(ValueError):
-        c.lr = {"schedule": 128}
+    c.lr = {"schedule": 128}
+    f = c.finalize()
+    assert f.lr.schedule == 128
+    assert "lr" not in f.to_flat_dict()
 
 
 def test_delete_group_and_leaf():

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -180,10 +180,10 @@ def test_create_or_set_with_walrus_top_level_and_nested():
     f4 = c2.finalize(["width:=64"])  # exact new top-level key
     assert f4.model.width == 128 and f4.width == 64
 
-    # Shadowing conflict: cannot set leaf where group exists
-    import pytest
-    with pytest.raises(ValueError):
-        c2.finalize(["model:=0"])  # group exists under 'model', cannot assign leaf
+    # Overwriting a group root with := clears the subtree
+    f5 = c2.finalize(["model:=0"])
+    assert f5.model == 0
+    assert "model.width" not in f5.to_flat_dict()
 
 
 def test_override_prefers_exact_key_when_using_c_prefix():

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -33,19 +33,20 @@ def test_run_with_config_and_overrides():
     assert unused == ["--extra", "pos"]
 
 
-def test_run_with_config_colon_func_and_group_override_ignored():
+def test_run_with_config_colon_func_and_group_override():
     cfg_path = os.path.join(os.path.dirname(__file__), "fixtures", "sample_config.py:get_config")
 
     def main(final, unused):
         return final, unused
 
-    import pytest
-    with pytest.raises(AttributeError):
-        _call_run([
-            f"--config={cfg_path}",
-            "model=bad",  # invalid: group assignment should raise
-            "model.depth=6",
-        ], main)
+    final, unused = _call_run([
+        f"--config={cfg_path}",
+        "model=bad",
+        "lr=0.2",
+    ], main)
+    assert final.model == "bad"
+    assert "model.width" not in final.to_flat_dict()
+    assert final.lr == 0.2
 
 def test_run_unknown_key_raises():
     cfg_path = os.path.join(os.path.dirname(__file__), "fixtures", "sample_config.py")


### PR DESCRIPTION
Allowed overwriting of inner nodes by making assignments last‑write‑wins and by letting CLI overrides target group roots, so `c.foo=None` now clears `foo.*` and `finalize(["foo=None"])` works as expected.

Behavior changes to be aware of:

- Group assignments like `c.model = "vit"` or CLI `model=vit` now replace the entire subtree instead of raising.
- After `model=vit`, a subsequent `model.depth=...` with `=` will be unknown unless you use `:=` (or reorder).
- Nested assignments under an existing leaf via flat keys or `:=` now drop the ancestor leaf to avoid shadowing.